### PR TITLE
Validate empty text elements

### DIFF
--- a/validations.go
+++ b/validations.go
@@ -47,7 +47,7 @@ func (s *Schema) validateNode(node *Node, def *Element) []string {
 	var errors []string
 
 	// Validate text content for leaf nodes
-	if len(node.Children) == 0 && strings.TrimSpace(node.Content) != "" {
+	if len(node.Children) == 0 {
 		errors = append(errors, s.validateTextContent(node, def)...)
 	}
 


### PR DESCRIPTION
## Summary

Remove check to validate if an element is a leaf text element. This check didn't identify empty text elements.
Fixes #5.

## Checklist

- [x] Tests added / updated
- [x] `go vet` and `go test` pass
- [x] `CHANGELOG.md` updated (if user-visible)
